### PR TITLE
Fix JS module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-geojson-parser#readme",
   "dependencies": {
+    "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
     "@types/geojson": "7946.0.2"
   },
   "scripts": {
@@ -28,7 +29,6 @@
     "lint": "tslint --project tsconfig.json --config tslint.json"
   },
   "devDependencies": {
-    "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
     "@types/jest": "^22.2.3",
     "@types/node": "9.6.5",
     "jest": "^22.4.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geostyler-geojson-parser",
   "version": "0.1.0",
   "description": "GeoStyler Data Parser implementation for GeoJSON",
-  "main": "index.js",
+  "main": "build/dist/GeoJsonDataParser.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/terrestris/geostyler-geojson-parser.git"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "url": "https://github.com/terrestris/geostyler-geojson-parser/issues"
   },
   "homepage": "https://github.com/terrestris/geostyler-geojson-parser#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@types/geojson": "7946.0.2"
+  },
   "scripts": {
     "pretest": "npm run lint",
     "test": "jest",
@@ -27,7 +29,6 @@
   },
   "devDependencies": {
     "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
-    "@types/geojson": "7946.0.2",
     "@types/jest": "^22.2.3",
     "@types/node": "9.6.5",
     "jest": "^22.4.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geostyler-geojson-parser",
   "version": "0.1.0",
   "description": "GeoStyler Data Parser implementation for GeoJSON",
-  "main": "src/GeoJsonDataParser.ts",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/terrestris/geostyler-geojson-parser.git"


### PR DESCRIPTION
This corrects the module export so this project is usable as package in other JavaScript projects. Mainly 2 things are done:

  - Declare  ``geostyler-data`` and ``@types/geojson`` as ``dependecies`` and not as ``devDependencies``
  - Let the main file point to the dist folder (so the transpiled version is used in imports)