### PR TITLE
Let readData implementation return a Promise

### DIFF
--- a/src/GeoJsonDataParser.spec.ts
+++ b/src/GeoJsonDataParser.spec.ts
@@ -81,37 +81,41 @@ describe('readData implementation', () => {
       ]
     };
 
-  it('works as expected and returns the correct data', () => {
+  it('works as expected and returns the correct data in a promise object', () => {
     const gjParser = new GeoJsonDataParser();
-    const output = gjParser.readData(geojson);
-    expect(output).toBeDefined();
-    expect(output.exampleFeatures.features.length).toBe(4);
 
-    const expectedSchema = {
-      'type': 'object',
-      'properties': {
-        'propString': {
-          'type': 'string'
-        },
-        'propNumber': {
-          'type': 'number',
-          'minimum': 10,
-          'maximum': 40
-        },
-        'propBoolean': {
-          'type': 'boolean'
-        },
-        'propArray': {
-          'type': 'array'
-        },
-        'anotherPropNumber': {
-          'type': 'number',
-          'minimum': 100.5,
-          'maximum': 400.5
-        },
-      }
-    };
-    expect(output.schema).toEqual(expectedSchema);
+    const promise = gjParser.readData(geojson);
+    promise.then((output) => {
+      expect(output).toBeDefined();
+      expect(output.exampleFeatures.features.length).toBe(4);
+
+      const expectedSchema = {
+        'type': 'object',
+        'properties': {
+          'propString': {
+            'type': 'string'
+          },
+          'propNumber': {
+            'type': 'number',
+            'minimum': 10,
+            'maximum': 40
+          },
+          'propBoolean': {
+            'type': 'boolean'
+          },
+          'propArray': {
+            'type': 'array'
+          },
+          'anotherPropNumber': {
+            'type': 'number',
+            'minimum': 100.5,
+            'maximum': 400.5
+          },
+        }
+      };
+      expect(output.schema).toEqual(expectedSchema);
+    });
+
   });
 
   it('exits when an invalid geojson is given as input', () => {

--- a/src/GeoJsonDataParser.ts
+++ b/src/GeoJsonDataParser.ts
@@ -19,14 +19,19 @@ class GeoJsonDataParser implements DataParser {
    * 
    * @param inputData 
    */
-  readData(inputData: any): Data {
+  readData(inputData: any): Promise<Data> {
 
     const featureCollection = inputData;
     const schema = this.parseSchema(featureCollection);
     
     const data = {schema: schema, exampleFeatures: featureCollection};
 
-    return data;
+    const promise = new Promise<Data>((resolve, reject) => {
+      // If we have a valid data object we can bind it to the promise resolver
+      resolve(data);
+    });
+
+    return promise;
   }
 
   /**


### PR DESCRIPTION
Due to the changes in the interface definition of the ``readData`` function (terrestris/geostyler-data#2) this adapts the concrete ``readData`` implementation for this parser, so it returns a Promise object.

Closes #10.

See https://github.com/terrestris/geostyler/issues/40 for more information.