### PR TITLE
Enable np for release on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "geostyler-geojson-parser",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "GeoStyler Data Parser implementation for GeoJSON",
   "main": "build/dist/GeoJsonDataParser.js",
+  "files": [
+    "build",
+    "index.d.ts"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/terrestris/geostyler-geojson-parser.git"
@@ -27,12 +31,14 @@
     "build": "tsc -p tsconfig.json",
     "pretest": "npm run lint",
     "test": "jest",
-    "lint": "tslint --project tsconfig.json --config tslint.json"
+    "lint": "tslint --project tsconfig.json --config tslint.json",
+    "release": "np --no-yarn"
   },
   "devDependencies": {
     "@types/jest": "22.2.3",
     "@types/node": "10.0.9",
     "jest": "22.4.3",
+    "np": "^2.20.1",
     "ts-jest": "22.4.6",
     "tslint": "5.10.0",
     "typescript": "2.8.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-geojson-parser#readme",
   "dependencies": {
-    "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
+    "geostyler-data": "0.1.0",
     "@types/geojson": "7946.0.3"
   },
   "scripts": {
@@ -38,7 +38,7 @@
     "@types/jest": "22.2.3",
     "@types/node": "10.0.9",
     "jest": "22.4.3",
-    "np": "^2.20.1",
+    "np": "2.20.1",
     "ts-jest": "22.4.6",
     "tslint": "5.10.0",
     "typescript": "2.8.3"


### PR DESCRIPTION
Enables the [np](https://www.npmjs.com/package/np) package to create and publish a release on [npmjs.com](https://www.npmjs.com)