### PR TITLE
Use 'commonjs' for module code generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "build/dist",
-    "module": "esnext",
+    "module": "commonjs",
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,


### PR DESCRIPTION
Use 'commonjs' for module code generation of TypeScript, so we get ES5 compliant module code.