### PR TITLE
Remove test files from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "acceptance-tests",
     "webpack",
     "jest",
+    "src/**.spec.ts",
     "src/setupTests.ts"
   ]
 }


### PR DESCRIPTION
Removes the unit test files from the build folder.

Fixes https://github.com/terrestris/geostyler/issues/119