### PR TITLE
Fix typeof check for array and browser build

### DIFF
--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,4 +1,4 @@
-const webpack = require("webpack");
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 require("@babel/polyfill");
 
 module.exports = {
@@ -23,6 +23,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
+    new UglifyJsPlugin(),
   ]
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ts-jest": "23.10.4",
     "tslint": "5.10.0",
     "typescript": "2.9.1",
+    "uglifyjs-webpack-plugin": "1.1.2",
     "webpack": "4.22.0",
     "webpack-cli": "3.1.2"
   },

--- a/src/GeoJsonDataParser.ts
+++ b/src/GeoJsonDataParser.ts
@@ -62,7 +62,10 @@ export class GeoJsonDataParser implements DataParser {
         for (let key of Object.keys(props)) {
           let propVal = props[key];
 
-          const propType: JSONSchema4TypeName = <JSONSchema4TypeName> typeof(propVal);
+          let propType: JSONSchema4TypeName = <JSONSchema4TypeName> typeof(propVal);
+          if (Array.isArray(propVal)) {
+            propType = 'array';
+          }
 
           if (propType === 'number') {
             if (!numValues[key]) {


### PR DESCRIPTION
typeof checks for arrays return `'object'`, not `'array'`. Thus, added dedicated check for arrays that returns `'array'`.

Also fixed browser-build