### PR TITLE
Fix error handling

### DIFF
--- a/src/GeoJsonDataParser.spec.ts
+++ b/src/GeoJsonDataParser.spec.ts
@@ -118,30 +118,32 @@ describe('readData implementation', () => {
 
   });
 
-  it('exits when an invalid geojson is given as input', () => {
+  it('rejects the promise if an invalid geojson is given as input', () => {
     const invalidGeojson = {
       type: 'FeatureCollection',
       foo: 'bar',
       kalle: 'Berga'
     };
     const gjParser = new GeoJsonDataParser();
-    let output;
-    try {
-      output = gjParser.readData(invalidGeojson);
-    } catch (error) {
-      expect(output).toBeUndefined();
-    }
+    gjParser.readData(invalidGeojson)
+      .then((data) => {
+        expect(data).toBeUndefined();
+      })
+      .catch((e) => {
+        expect(e).toBeDefined();
+      });
   });
 
-  it('exits when an invalid data is given as input', () => {
+  it('rejects the promise if an invalid data is given as input', () => {
     const invalidData = '<?xml version="1.0" encoding="UTF-8"?><foo>123</foo>';
     const gjParser = new GeoJsonDataParser();
-    let output;
-    try {
-      output = gjParser.readData(invalidData);
-    } catch (error) {
-      expect(output).toBeUndefined();
-    }
+    gjParser.readData(invalidData)
+      .then((data) => {
+        expect(data).toBeUndefined();
+      })
+      .catch((e) => {
+        expect(e).toBeDefined();
+      });
   });
 
 });

--- a/src/GeoJsonDataParser.ts
+++ b/src/GeoJsonDataParser.ts
@@ -28,18 +28,18 @@ export class GeoJsonDataParser implements DataParser {
    * @param inputData
    */
   readData(inputData: any): Promise<Data> {
+    return new Promise<Data>((resolve, reject) => {
+      try {
+        const featureCollection = inputData;
+        const schema = this.parseSchema(featureCollection);
 
-    const featureCollection = inputData;
-    const schema = this.parseSchema(featureCollection);
-
-    const data = {schema: schema, exampleFeatures: featureCollection};
-
-    const promise = new Promise<Data>((resolve, reject) => {
-      // If we have a valid data object we can bind it to the promise resolver
-      resolve(data);
+        const data = {schema: schema, exampleFeatures: featureCollection};
+          // If we have a valid data object we can bind it to the promise resolver
+        resolve(data);
+      } catch (e) {
+        reject(e);
+      }
     });
-
-    return promise;
   }
 
   /**


### PR DESCRIPTION
The parser threw an error if input types were invalid. Since a promise will be returned, the parser now catches errors and then rejects the promise. Updated tests accordingly.

@terrestris/devs please review.